### PR TITLE
docs: update urls to WICG repo

### DIFF
--- a/research/gatsby-config.js
+++ b/research/gatsby-config.js
@@ -6,7 +6,7 @@ module.exports = {
     title: 'Open UI',
     description: 'Open UI ',
     author: 'Open UI',
-    githubURL: 'https://github.com/stardust-ui/specifications',
+    githubURL: 'https://github.com/WICG/open-ui',
   },
 
   plugins: [

--- a/research/package.json
+++ b/research/package.json
@@ -5,7 +5,7 @@
   "author": "Open UI",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stardust-ui/specifications"
+    "url": "https://github.com/WICG/open-ui"
   },
   "keywords": [
     "open ui"


### PR DESCRIPTION
This updates the github links in the live docs to point to this repo, instead of the Stardust repo.

👍 