### PR TITLE
Remove empty switch page

### DIFF
--- a/research/src/pages/switch.mdx
+++ b/research/src/pages/switch.mdx
@@ -2,7 +2,6 @@
 menu: Components
 name: Switch
 path: /components/switch
-research: /components/switch.research
 ---
 
 import Anatomy from '../components/anatomy'

--- a/research/src/pages/switch.research.mdx
+++ b/research/src/pages/switch.research.mdx
@@ -1,8 +1,0 @@
----
-menu: Components
-name: Switch
-path: /components/switch.research
-researchFor: /components/switch
----
-
-...


### PR DESCRIPTION
This is just a cleanup PR.  We needed at least one page with a `researchFor` front matter entry in order for the build to be happy.  Now that we have a real research page (`select`), we no longer need this stub page.