### PR TITLE
Attempt to improve alt text for images

### DIFF
--- a/research/src/components/specimens.js
+++ b/research/src/components/specimens.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import React from 'react'
+import { kebabCaseToSentence, removeExtensionFromFilename } from '../utils/text'
 import { getImagesForComponentConcept } from '../sources'
 import Image from './image'
 
@@ -15,9 +16,11 @@ const Specimens = ({ component, concept }) => {
         border: '1px solid #ccc',
       }}
     >
-      {images.map((src, i) => (
-        <Image key={i} src={src} title={src} />
-      ))}
+      {images.map((src, i) => {
+        const srcNameAsSentence = kebabCaseToSentence(removeExtensionFromFilename(src))
+
+        return <Image key={i} alt={srcNameAsSentence} src={src} title={srcNameAsSentence} />
+      })}
     </div>
   )
 }

--- a/research/src/utils/text.js
+++ b/research/src/utils/text.js
@@ -1,0 +1,23 @@
+/**
+ * Transforms a provided string using kebab-case as a sentence with spaces
+ *
+ * @param {string} string String to convert as a sentence
+ */
+export function kebabCaseToSentence(string) {
+  const stringWithoutDashes = string.replace(/-/g, ' ')
+  const firstChar = stringWithoutDashes.charAt().toUpperCase()
+
+  return firstChar + stringWithoutDashes.slice(1)
+}
+
+/**
+ * Removes the extension from a filename provided as a string
+ *
+ * @param {string} string Filename to remove the extension from
+ */
+export function removeExtensionFromFilename(string) {
+  return string
+    .split('.')
+    .slice(0, -1)
+    .join('.')
+}


### PR DESCRIPTION
Hello folks :) 

Following the issue #40 opened by @LJWatson regarding the lack of usefulness of the `alt` present on images in pages like [button](https://open-ui.org/components/button), I made this PR as an attempt to fix this.

From what I saw, the image name is following a structure like `system-component-variation.extension`. My idea was to simply transform this kebab case name to a real sentence.
For example, this PR is transforming the `carbon-button-primary` alt attribute to be `Carbon button primary`. 

In my opinion, this script is not replacing what could be offered by a having a real alt description for each image but it might provide a better experience for screen readers based on the current information available.

If you're happy with this solution, I was wondering if this script should be part of the `Specimens` component (as proposed by this pull request) or if it should be part of the `image` component, by replacing the current `alt = src` default value attribution.

What do you think about it?

--- 

Could close #40 