### PR TITLE
Improve image alt tags and specimens

### DIFF
--- a/research/src/components/concepts.js
+++ b/research/src/components/concepts.js
@@ -9,7 +9,7 @@ const Concepts = ({ component }) => {
     <div>
       {_.map(conceptsByComponent[component], (concept, conceptOpenUIName) => (
         <div key={conceptOpenUIName}>
-          <h3>
+          <h3 style={{ marginTop: '24px' }}>
             {conceptOpenUIName}{' '}
             <ConceptCoverage component={component} concept={conceptOpenUIName} />
           </h3>

--- a/research/src/components/layout.js
+++ b/research/src/components/layout.js
@@ -63,21 +63,15 @@ const Layout = ({ children, pageContext }) => {
             />
             <div
               style={{
-                display: 'grid',
-                gridGap: '2em',
-                gridTemplate: `
-                "nav  view" auto /
-                 auto 1fr
-              `,
+                display: 'flex',
                 padding: '0 1rem',
                 margin: '0 auto',
                 maxWidth: '1200px',
-                gridAutoFlow: 'rows',
               }}
             >
-              <Navigation style={{ gridArea: 'nav' }} />
+              <Navigation style={{ marginRight: '1em' }} />
 
-              <div style={{ gridArea: 'view' }}>
+              <div style={{ flex: '1' }}>
                 <ContentWrapper frontmatter={frontmatter}>{children}</ContentWrapper>
               </div>
             </div>

--- a/research/src/components/specimens.js
+++ b/research/src/components/specimens.js
@@ -10,13 +10,46 @@ const Specimens = ({ component, concept }) => {
   return (
     <div
       style={{
-        padding: hasImages ? '1em' : '2em',
-        marginBottom: '2em',
+        display: 'flex',
+        flexWrap: 'wrap',
+        marginBottom: '8px',
         border: '1px solid #ccc',
       }}
     >
-      {images.map((src, i) => (
-        <Image key={i} src={src} title={src} />
+      {images.map((image, i) => (
+        <div
+          key={i}
+          style={{
+            display: 'flex',
+            flex: '0 0 auto',
+            flexDirection: 'column',
+            padding: hasImages ? '8px' : '16px',
+            textAlign: 'center',
+          }}
+        >
+          <div style={{ margin: 'auto', padding: '4px' }}>
+            <Image
+              src={image.image}
+              title={image.image}
+              alt={`An image of the ${concept} concept on a ${component} component in ${image.sourceName}.`}
+            />
+          </div>
+          <div
+            style={{
+              position: 'relative',
+              padding: '4px 8px',
+              minWidth: '120px',
+              textTransform: 'uppercase',
+              fontSize: '11px',
+              lineHeight: 1,
+              whiteSpace: 'nowrap',
+              color: 'rgba(0, 0, 0, 0.6)',
+              borderTop: '1px solid #ccc',
+            }}
+          >
+            {image.sourceName}
+          </div>
+        </div>
       ))}
     </div>
   )

--- a/research/src/sources/index.js
+++ b/research/src/sources/index.js
@@ -91,9 +91,7 @@ export const getSourcesWithComponentConcept = (componentOpenUIName, conceptOpenU
 
 // Images
 export const getImagesForComponentConcept = (componentOpenUIName, conceptOpenUIName) => {
-  return _.compact(
-    _.map(_.get(conceptsByComponent, [componentOpenUIName, conceptOpenUIName]), 'image'),
-  )
+  return _.compact(_.map(_.get(conceptsByComponent, [componentOpenUIName, conceptOpenUIName])))
 }
 
 // Images for component


### PR DESCRIPTION
Fixes #40 

This PR fixes image alt tags.  In order to do this, the function for returning images was updated to include the design data.  We now have nice alt tags and images grouped by design system.

# Before

![image](https://user-images.githubusercontent.com/5067638/77119175-2b247380-69f3-11ea-84cc-5994b6852da5.png)

![image](https://user-images.githubusercontent.com/5067638/77119341-7d659480-69f3-11ea-96a6-62d71c80b02c.png)

# After

![image](https://user-images.githubusercontent.com/5067638/77119964-e0a3f680-69f4-11ea-9d17-d99ff8ddfac4.png)

![image](https://user-images.githubusercontent.com/5067638/77119357-87879300-69f3-11ea-84e2-1949bd830f4e.png)