### PR TITLE
Added the web platform specific controls

### DIFF
--- a/research/src/sources/index.js
+++ b/research/src/sources/index.js
@@ -14,6 +14,7 @@ import primer from './primer.json5'
 import semantic from './semantic.json5'
 import stardust from './stardust.json5'
 import w3 from './w3.json5'
+import web from './web.json5'
 
 // Sources
 export const sources = [
@@ -31,6 +32,7 @@ export const sources = [
   semantic,
   stardust,
   w3,
+  web,
 ].map(source => ({
   ...source,
   components: source.components.map(component => {

--- a/research/src/sources/web.json5
+++ b/research/src/sources/web.json5
@@ -1,0 +1,154 @@
+{
+  "$schema": "../schemas/design-system.schema.json5",
+  "lastUpdated": "2020-03-30",
+  "name": "Web Platform",
+  "description": "This represents the components that ship by default in browsers and have been standardized.",
+  "url": "https://html.spec.whatwg.org/multipage/",
+  "by": "WHATWG & W3C",
+  "components": [
+    {
+      "name": "Button",
+      "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element"
+    },
+    {
+      "name": "Checkbox",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)"
+    },
+    {
+      "name": "Radio",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)"
+    },
+    {
+      "name": "Datalist",
+      "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-datalist-element"
+    },
+    {
+      "name": "Select",
+      "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element"
+    },
+    {
+      "name": "Meter",
+      "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element"
+    },
+    {
+      "name": "Details",
+      "url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element"
+    },
+    {
+      "name": "Legend",
+      "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-legend-element"
+    },
+    {
+      "name": "Label",
+      "url": "https://html.spec.whatwg.org/multipage/forms.html#the-label-element"
+    },
+    {
+      "name": "A",
+      "url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
+    },
+    {
+      "name": "Search",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)"
+    },
+    {
+      "name": "Range",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)"
+    },
+    {
+      "name": "Number",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)"
+    },
+    {
+      "name": "Text",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)"
+    },
+    {
+      "name": "Date",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date)"
+    },
+    {
+      "name": "Color",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#color-state-(type=color)"
+    },
+    {
+      "name": "Ul",
+      "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element"
+    },
+    {
+      "name": "Ol",
+      "url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
+    },
+    {
+      "name": "Nav",
+      "url": "https://html.spec.whatwg.org/multipage/sections.html#the-nav-element"
+    },
+    {
+      "name": "Progress",
+      "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element"
+    },
+    {
+      "name": "Dialog",
+      "url": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element"
+    },
+    {
+      "name": "Img",
+      "url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"
+    },
+    {
+      "name": "Img",
+      "url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"
+    },
+    {
+      "name": "Picture",
+      "url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element"
+    },
+    {
+      "name": "Video",
+      "url": "https://html.spec.whatwg.org/multipage/media.html#the-video-element"
+    },
+    {
+      "name": "Audio",
+      "url": "https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
+    },
+    {
+      "name": "File",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)"
+    },
+    {
+      "name": "Submit",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#submit-button-state-(type=submit)"
+    },
+    {
+      "name": "Reset",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#reset-button-state-(type=reset)"
+    },
+    {
+      "name": "Time",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#time-state-(type=time)"
+    },
+    {
+      "name": "Month",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#month-state-(type=month)"
+    },
+    {
+      "name": "Week",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#week-state-(type=week)"
+    },
+    {
+      "name": "URL",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#url-state-(type=url)"
+    },
+    {
+      "name": "Password",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#password-state-(type=password)"
+    },
+    {
+      "name": "Email",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)"
+    },
+    {
+      "name": "Telephone",
+      "url": "https://html.spec.whatwg.org/multipage/input.html#telephone-state-(type=tel)"
+    }
+  ]
+}


### PR DESCRIPTION
Currently the component matrix contains the content for WIA-ARIA but these are not a 1:1 with the actual controls that ship with the browser. As such I'm adding in a web platform section that has the majority of our controls. I did not add in JS invoked controls, merely the HTML ones. I figured most of the JS ones are covered by WIA-ARIA.