### PR TITLE
Adding initial editors for select & template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,15 @@
 
 /platform/  @gregwhitworth
 /research/  @levithomason
+
+
+# Editors
+# --------------------------------
+
+# Specification Template
+/research/src/pages/component-spec-template.mdx   @EisenbergEffect
+
+# Select
+/research/src/pages/select.research.mdx           @gregwhitworth
+/research/src/pages/select.proposal.mdx           @gregwhitworth
+/research/src/pages/select.behavior.mdx           @gregwhitworth


### PR DESCRIPTION
This is a simple change based on our resolution for adding editors.

This is to add editors for select and the spec template of @EisenbergEffect in addition to Levi and Myself.

I need approval from you @levithomason and it would be good to ensure that you want this responsibility @EisenbergEffect :)