### PR TITLE
Fix build break from wrong param passed to <ConceptCoverage>

### DIFF
--- a/research/src/components/concepts.js
+++ b/research/src/components/concepts.js
@@ -43,13 +43,13 @@ const Concepts = ({ component }) => {
                 <ConceptCoverage
                   component={component}
                   openUIConceptName={conceptOpenUIName}
-                  conceptName={conceptOpenUIName}
+                  conceptName={uniqueNames[0]}
                 />
               )}
             </h3>
             {hasOtherNames && (
               <div style={{ color: '#777', lineHeight: 1, marginBottom: '.5em' }}>
-                {uniqueNames.map(otherName => (
+                {uniqueNames.map((otherName) => (
                   <div key={otherName}>
                     <ConceptCoverage
                       component={component}

--- a/research/src/sources/semantic.json5
+++ b/research/src/sources/semantic.json5
@@ -462,7 +462,6 @@
         },
         {
           "name": "minCharacters",
-          "openUIName": "minCharsBeforeSearch",
           "description": "The minimum characters for a search to begin showing results"
         },
         {

--- a/research/src/sources/semantic.json5
+++ b/research/src/sources/semantic.json5
@@ -462,6 +462,7 @@
         },
         {
           "name": "minCharacters",
+          "openUIName": "minCharsBeforeSearch",
           "description": "The minimum characters for a search to begin showing results"
         },
         {


### PR DESCRIPTION
This PR fixes a build break caused by an instance of `<ConceptCoverage>` in concepts.js where the conceptOpenUIName was being passed to the conceptName parameter.  This resulted in a failed lookup when we try to search the concept framework-specific names for the openUIName.  The fix is to pass the uniqueName to the parameter instead.

This was triggered by Semantic's Select's minCharacters which has an openUIName that is not present anywhere else, with the result that we went down the buggy codepath.