### PR TITLE
Added definitions to contribute

### DIFF
--- a/research/src/components/navigation.js
+++ b/research/src/components/navigation.js
@@ -67,6 +67,32 @@ const Navigation = ({ style }) => (
       return (
         <nav style={style}>
           <ul style={{ position: 'sticky', top: '1em', margin: 0 }}>
+            <li
+              key="Home"
+              style={{
+                margin: 0,
+                listStyleType: 'none',
+              }}
+            >
+              <Link
+                to="/"
+                style={{
+                  display: 'block',
+                  padding: '0.25em 1em 0.25em 0.5em',
+                  margin: 0,
+                  color: 'inherit',
+                  borderLeft: '2px solid transparent',
+                  borderRadius: '2px',
+                  whiteSpace: 'nowrap',
+                }}
+                activeStyle={{
+                  borderLeftColor: '#00a453',
+                  backgroundColor: '#f2f2f2',
+                }}
+              >
+                Home
+              </Link>
+            </li>
             {topLevelNodes.map(listItem)}
 
             <div style={{ margin: '1rem' }} />

--- a/research/src/pages/contribute.mdx
+++ b/research/src/pages/contribute.mdx
@@ -72,7 +72,7 @@ A design system does not need to meet all of these criteria but it should meet m
 The design systems we've launched with we believe are representative of these criteria.
 We may not accept PRs contributing design systems that are lacking by these criteria.
 
-### Adding a design system <a href="#add-a-design-system" id="add-a-design-systems"></a>
+### Adding a design system <a href="#add-a-design-system" id="add-a-design-system"></a>
 
 Create a JSON5 file in `/sources` for the design system, like `/antd.json5`.
 Add the `$schema` key pointing to our `design-system.schema.json5` schema and complete the required fields.
@@ -280,11 +280,18 @@ some common terms used in specifications and their definitions.
 
 The dictionary defines a component as, "a part or element of a larger whole" and this is
 true for components in a design system's component library. Components normally have a meaning,
-although this meaning may not be presented to the user (such as a utility component). A component,
-as the definition states can be a part of another component which are known as **composite components**.
+although this meaning may not be presented to the user (such as a utility component). The _meaning_ is
+defined by the component's model, defined [parts](https://drafts.csswg.org/css-shadow-parts-1/#part-attr) and
+[slots](https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element), and states.
 
 ## Control <a href="#definition-control" id="definition-control"></a>
 
-A control is a subset of component that allows some form of user interaction. Controls have a defined model,
-known [parts](https://drafts.csswg.org/css-shadow-parts-1/#part-attr) and [slots](https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element),
-possible states, and controller code that manages the transition of states and the model based on end user interaction with the defined parts.
+A control is a subset of component that allows some form of user interaction. The control has controller code
+that manages the transition of the component's states and the model based on end user interaction with the
+defined parts.
+
+## Composite Component
+
+It is often necessary to produce a component that contains other components. For example, the `<file>`
+control is a component that normally contains an `<input>` component and a `<button>` component.
+These types of components are commonly referred to as composite components.

--- a/research/src/pages/contribute.mdx
+++ b/research/src/pages/contribute.mdx
@@ -46,7 +46,7 @@ if you have any questions then that means that our documentation can be improved
 
 # Design Systems <a href="#design-systems" id="design-systems"></a>
 
-Open UI uses design systems and component as one of its forms of evidence for cataloging emergent UI standards.
+Open UI uses design systems as one of its forms of evidence for cataloging emergent UI standards.
 Design systems are documented in JSON5 format according a JSON schema.
 This provides us with a consistent and machine readable way of documenting the design system.
 
@@ -159,6 +159,13 @@ If the image requires showing motion or interaction, considering using a gif too
 
 <Image src="sui-button-animated.gif" alt="Semantic UI Animated Button" />
 
+### Try it out
+
+You should now be able to `yarn start` the docs and see your component in the menu.
+You should also have a toggle on the component page to switch between the proposal page and research page.
+
+:smile: You're all set! We're looking forward to your contribution to Open UI!
+
 # Creating a component spec <a href="#document-component" id="document-component"></a>
 
 Adding a component to Open UI is a research process.
@@ -268,9 +275,21 @@ denote them, they'll be incremented automatically and pre-pended with 'Question'
 
 `<p class="question">QUESTION</p>`
 
-### Try it out
+# Definitions <a href="#whats-a-component"></a>
 
-You should now be able to `yarn start` the docs and see your component in the menu.
-You should also have a toggle on the component page to switch between the proposal page and research page.
+Since Open UI is about doing research across design systems to understand their components
+and controls it's important to have clear definitions. For the purposes of Open UI here are
+some common terms used in specifications and their definitions.
 
-:smile: You're all set! We're looking forward to your contribution to Open UI!
+## Component
+
+The dictionary defines a component as, "a part or element of a larger whole" and this is
+true for components in a design system's component library. Components normally have a meaning,
+although this meaning may not be presented to the user (such as a utility component). A component,
+as the definition states can be a part of another component which are known as **composite components**.
+
+## Control
+
+A control is a subset of component that allows some form of user interaction. Controls have a defined model,
+known [parts](https://drafts.csswg.org/css-shadow-parts-1/#part-attr) and [slots](https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element),
+possible states, and controller code that manages the transition of states and the model based on end user interaction with the defined parts.

--- a/research/src/pages/contribute.mdx
+++ b/research/src/pages/contribute.mdx
@@ -16,14 +16,10 @@ if you have any questions then that means that our documentation can be improved
     <strong>Design Systems</strong>
     <ul>
       <li>
-        <a href="#add-a-design-system" id="add-a-design-systems">
-          Add a design system
-        </a>
+        <a href="#add-a-design-system">Add a design system</a>
       </li>
       <li>
-        <a href="#add-design-system-component" id="add-design-system-component">
-          Adding a design system component
-        </a>
+        <a href="#add-design-system-component">Adding a design system component</a>
       </li>
     </ul>
   </li>
@@ -31,16 +27,15 @@ if you have any questions then that means that our documentation can be improved
     <strong>Creating a component spec</strong>
     <ul>
       <li>
-        <a href="#research-page" id="research-page">
-          Research Page
-        </a>
+        <a href="#research-page">Research Page</a>
       </li>
       <li>
-        <a href="#proposal-page" id="proposal-page">
-          Proposal Page
-        </a>
+        <a href="#proposal-page">Proposal Page</a>
       </li>
     </ul>
+  </li>
+  <li>
+    <a href="#definitions">Definitions</a>
   </li>
 </ul>
 
@@ -275,20 +270,20 @@ denote them, they'll be incremented automatically and pre-pended with 'Question'
 
 `<p class="question">QUESTION</p>`
 
-# Definitions <a href="#whats-a-component"></a>
+# Definitions <a href="#definitions" id="definitions"></a>
 
 Since Open UI is about doing research across design systems to understand their components
 and controls it's important to have clear definitions. For the purposes of Open UI here are
 some common terms used in specifications and their definitions.
 
-## Component
+## Component <a href="#definition-component" id="definition-component"></a>
 
 The dictionary defines a component as, "a part or element of a larger whole" and this is
 true for components in a design system's component library. Components normally have a meaning,
 although this meaning may not be presented to the user (such as a utility component). A component,
 as the definition states can be a part of another component which are known as **composite components**.
 
-## Control
+## Control <a href="#definition-control" id="definition-control"></a>
 
 A control is a subset of component that allows some form of user interaction. Controls have a defined model,
 known [parts](https://drafts.csswg.org/css-shadow-parts-1/#part-attr) and [slots](https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element),

--- a/research/src/pages/contribute.mdx
+++ b/research/src/pages/contribute.mdx
@@ -286,7 +286,7 @@ defined by the component's model, defined [parts](https://drafts.csswg.org/css-s
 
 ## Control <a href="#definition-control" id="definition-control"></a>
 
-A control is a subset of component that allows some form of user interaction. The control has controller code
+A control is a type of component that allows some form of user interaction. The control has controller code
 that manages the transition of the component's states and the model based on end user interaction with the
 defined parts.
 

--- a/research/src/pages/contribute.mdx
+++ b/research/src/pages/contribute.mdx
@@ -7,7 +7,46 @@ import Image from '../components/image'
 
 # Contribute
 
-Open UI uses design systems as one of its forms of evidence for cataloging emergent UI standards.
+We welcome any contributions that you're willing to make, whether it be in the research of a component
+or in defining specific behaviors or parts of a component. Below are ways in which you can help contribute,
+if you have any questions then that means that our documentation can be improved - please file an [issue](https://github.com/WICG/open-ui/issues) :bug:
+
+<ul>
+  <li>
+    <strong>Design Systems</strong>
+    <ul>
+      <li>
+        <a href="#add-a-design-system" id="add-a-design-systems">
+          Add a design system
+        </a>
+      </li>
+      <li>
+        <a href="#add-design-system-component" id="add-design-system-component">
+          Adding a design system component
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <strong>Creating a component spec</strong>
+    <ul>
+      <li>
+        <a href="#research-page" id="research-page">
+          Research Page
+        </a>
+      </li>
+      <li>
+        <a href="#proposal-page" id="proposal-page">
+          Proposal Page
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+
+# Design Systems <a href="#design-systems" id="design-systems"></a>
+
+Open UI uses design systems and component as one of its forms of evidence for cataloging emergent UI standards.
 Design systems are documented in JSON5 format according a JSON schema.
 This provides us with a consistent and machine readable way of documenting the design system.
 
@@ -38,7 +77,7 @@ A design system does not need to meet all of these criteria but it should meet m
 The design systems we've launched with we believe are representative of these criteria.
 We may not accept PRs contributing design systems that are lacking by these criteria.
 
-## Adding a design system
+### Adding a design system <a href="#add-a-design-system" id="add-a-design-systems"></a>
 
 Create a JSON5 file in `/sources` for the design system, like `/antd.json5`.
 Add the `$schema` key pointing to our `design-system.schema.json5` schema and complete the required fields.
@@ -53,7 +92,7 @@ Add the `$schema` key pointing to our `design-system.schema.json5` schema and co
 }
 ```
 
-### Adding your design system's component
+### Adding your design system's component <a href="#add-design-system-component" id="add-design-system-component"></a>
 
 After you create the base schema file, add in each component for your design system into a `components` array that
 resides in the schema document. This information will populate the [Component Name Matrix](https://open-ui.org/analysis/component-matrix).
@@ -120,7 +159,7 @@ If the image requires showing motion or interaction, considering using a gif too
 
 <Image src="sui-button-animated.gif" alt="Semantic UI Animated Button" />
 
-## Document a component using research and proposal pages
+# Creating a component spec <a href="#document-component" id="document-component"></a>
 
 Adding a component to Open UI is a research process.
 Because of this, two pages are created for each component; a research page and a proposal page.
@@ -148,7 +187,7 @@ and paste it into your proposal document.
 
 :bulb: These pages will be displayed as a single page on Open UI.
 
-### Research Page
+## Research Page <a href="#research-page" id="research-page"></a>
 
 The research page is a place to collect, analyse, and deeply understand the data available on the component.
 
@@ -175,7 +214,7 @@ following `<component-name.research.<research-topic>.mdx`.
 Link to these documents within your research page under a section title accordingly. For example, the `<select>`
 control has research pages for behaviors.
 
-### Proposal Page
+## Proposal Page <a href="#proposal-page" id="proposal-page"></a>
 
 The proposal page will summarize your findings, conclusions, and unresolved points.
 
@@ -191,20 +230,20 @@ pathToResearch: /components/your-component.research
 ---
 ```
 
-**Working through the proposal template**
+### Working through the proposal template
 
 Beginning to spec a control can feel daunting and it's hard to know where to start.
 The spec template headings should be used as a guide to ensure that all aspects of creating
 a high quality control that is inclusive for all users is covered. Not all sections are required for
 every control. If you remove them, make sure to denote that you removed them and why in a PR.
 
-**Gaining consensus on a change**
+### Gaining consensus on a change
 
 Of course, merely documenting what exists does not necessarily make something a good design.
 For each normative change that you make to your spec proposal, open an issue to outline the change
 that you're proposing. You should provide any research to support the change(s) that you're proposing.
 
-**Do NOT deviate from already standardized content**
+### Do **NOT** deviate from already standardized content
 
 Open UI is trying to define an entire control in a single location. Currently, in order to
 build a complete control you'll need to refer to specifications in WHATWG, CSSWG, and WIA-ARIA.
@@ -222,14 +261,14 @@ to be filed again the WHATWG HTML specification.
 
 **Note:** In order to understand how Open UI achieves consensus, please review to our [charter](https://open-ui.org/charter)
 
-## Denoting Questions
+### Denoting Questions
 
 There is an expectation that your proposal will have open questions. Leverage the following HTML to
 denote them, they'll be incremented automatically and pre-pended with 'Question'.
 
 `<p class="question">QUESTION</p>`
 
-## Try it out
+### Try it out
 
 You should now be able to `yarn start` the docs and see your component in the menu.
 You should also have a toggle on the component page to switch between the proposal page and research page.

--- a/research/src/pages/mission.research.mdx
+++ b/research/src/pages/mission.research.mdx
@@ -2,6 +2,7 @@
 title: Open UI
 name: Home
 path: /
+showInMenu: false
 ---
 
 > This project is in its infancy. Expect rapid iteration and high-flux while we flesh out the mission and process.


### PR DESCRIPTION
I've updated the contribution document again. This time adding a terrible subnav at the top of the document but will hopefully allow people to jump down a bit quicker. Added in some anchors for sharing. Also added in some definitions for use across documents. The definition of a control is the important aspect as that is what is outlined in each of our specs as top level sections.

Also forced Home to be the first nav item.

This resolves #81 