### PR TITLE
Updated anatomy with named outer slots

### DIFF
--- a/research/src/components/anatomy.css
+++ b/research/src/components/anatomy.css
@@ -62,6 +62,10 @@
   content: "slot";
 }
 
+.component-anatomy slot:not([name=""])::before {
+  content:  attr(name) " [slot]";
+}
+
 .component-anatomy host {
   border: 5px solid black;
 }

--- a/research/src/components/select-anatomy.js
+++ b/research/src/components/select-anatomy.js
@@ -22,11 +22,7 @@ const SelectAnatomy = () => {
               <slot>
                 <div class="element">
                   <div class="anatomy-label" name="optgroup" data-slot></div>
-                  <slot>
-                    <part name="option" data-slot>
-                      <slot>Content</slot>
-                    </part>
-                  </slot>
+                  <part name="option" data-slot></part>
                 </div>
               </slot>
             </part>

--- a/research/src/components/select-anatomy.js
+++ b/research/src/components/select-anatomy.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import React from 'react'
 import './anatomy.css'
 
@@ -8,26 +10,24 @@ const SelectAnatomy = () => {
       <label for="show-slots"> Show slots</label>
       <div class="component-anatomy">
         <host name="select" data-slot>
-          <slot>
-            <slot data-slot>
-              <part name="button" data-slot>
-                <slot>Currently selected option</slot>
-              </part>
-            </slot>
-            <slot data-slot>
-              <part name="listbox" data-slot>
-                <slot>
-                  <div class="element">
-                    <div class="anatomy-label" name="optgroup" data-slot></div>
-                    <slot>
-                      <part name="option" data-slot>
-                        <slot>Content</slot>
-                      </part>
-                    </slot>
-                  </div>
-                </slot>
-              </part>
-            </slot>
+          <slot name="button-wrapper" data-slot>
+            <part name="button" data-slot>
+              <slot>Currently selected option</slot>
+            </part>
+          </slot>
+          <slot name="listbox-wrapper" data-slot>
+            <part name="listbox" data-slot>
+              <slot>
+                <div class="element">
+                  <div class="anatomy-label" name="optgroup" data-slot></div>
+                  <slot>
+                    <part name="option" data-slot>
+                      <slot>Content</slot>
+                    </part>
+                  </slot>
+                </div>
+              </slot>
+            </part>
           </slot>
         </host>
       </div>

--- a/research/src/components/select-anatomy.js
+++ b/research/src/components/select-anatomy.js
@@ -12,7 +12,7 @@ const SelectAnatomy = () => {
         <host name="select" data-slot>
           <slot name="button-wrapper" data-slot>
             <part name="button" data-slot>
-              <slot>Currently selected option</slot>
+              <slot name="selected-value">Currently selected value</slot>
             </part>
           </slot>
           <slot name="listbox-wrapper" data-slot>

--- a/research/src/components/select-anatomy.js
+++ b/research/src/components/select-anatomy.js
@@ -10,12 +10,14 @@ const SelectAnatomy = () => {
       <label for="show-slots"> Show slots</label>
       <div class="component-anatomy">
         <host name="select" data-slot>
-          <slot name="button-wrapper" data-slot>
+          <slot name="button-container" data-slot>
             <part name="button" data-slot>
-              <slot name="selected-value">Currently selected value</slot>
+              <slot name="selected-value">
+                <part name="selected-value">Currently selected value</part>
+              </slot>
             </part>
           </slot>
-          <slot name="listbox-wrapper" data-slot>
+          <slot name="listbox-container" data-slot>
             <part name="listbox" data-slot>
               <slot>
                 <div class="element">

--- a/research/src/components/specimens.js
+++ b/research/src/components/specimens.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import React from 'react'
 import { getImagesForComponentConcept } from '../sources'
 import Image from './image'
@@ -8,7 +7,7 @@ const Specimens = ({ component, conceptName, showDescriptions }) => {
 
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap', border: '1px solid #ccc' }}>
-      {images.map(image => {
+      {images.map((image) => {
         const hasOverrideName = image.name !== image.openUIName
 
         return (

--- a/research/src/styles/spec.css
+++ b/research/src/styles/spec.css
@@ -13,13 +13,3 @@
     margin-right: .5em;
     font-weight: bold;
 }
-
-.link {
-    display: inline-block;
-    font-family: sans-serif;
-    color: #ccc;
-}
-
-.link::before {
-    content: "#";
-}


### PR DESCRIPTION
This PR does the following and will resolve #80 

I have added tentative names for the slots that are outside of the defined parts. While working on the checkbox @nicholasrice brought up a valid question of why we would want to allow the author to completely replace an entire part. This is to ensure that we aren't locking in current anatomies and behaviors completely. This would allow authors to replace the light DOM with their own variation of part. For example:

```
<select>
    <div slot="button-wrapper">
       <p>I'm able to put whatever I want in here, no limitations</p>
       <div part="button">This is the button that will trigger the open state of the <select>
    </div>
    <div part="list-box">
        ... options ...
    </div>
</select>
```

This will allow our controller code that knows to look for the button part and attach necessary event listeners while allowing the author to replace only the part they truly care about. @dandclark if you can take a glance at the anatomy itself and naming I'd appreciate it. Here is the anatomy in image form:

![image](https://user-images.githubusercontent.com/865244/83299279-b74cd700-a1aa-11ea-8183-abd2bb8f895d.png)
