### PR TITLE
image: Don't use the non-standard zoom property to shrink images.

### DIFF
--- a/research/src/components/image.js
+++ b/research/src/components/image.js
@@ -9,11 +9,10 @@ const Image = ({ src, alt = src, style, ...rest }) => {
   return (
     <img
       alt={alt}
-      src={imageData}
+      srcset={imageData + ' 2x'}
       style={{
         display: 'inline-block',
         verticalAlign: 'middle',
-        zoom: 0.5,
         margin: 0,
         ...style,
       }}


### PR DESCRIPTION
Use the standard srcset instead.