### PR TITLE
fix: wires select's click handler using imperative syntax

### DIFF
--- a/components/src/select/demos/bootstrap-split/index.html
+++ b/components/src/select/demos/bootstrap-split/index.html
@@ -122,5 +122,11 @@
         </oui-select>
 
     <script src="/dist/bundle.js"></script>
+    <script>
+        document.querySelector("[part='button']").addEventListener("click", e => {
+          console.log("external", e, e.target)
+          e.stopPropagation();
+        })
+    </script>
   </body>
 </html>

--- a/components/src/select/select.template.ts
+++ b/components/src/select/select.template.ts
@@ -1,4 +1,4 @@
-import { html, slotted } from "@microsoft/fast-element";
+import { html, slotted, ref } from "@microsoft/fast-element";
 import { Select } from "./select";
 
 export const SelectTemplate = html<Select>`
@@ -12,8 +12,8 @@ export const SelectTemplate = html<Select>`
     class="${x => (x.readOnly ? "readonly" : "")}" open="${x => x.open ? "" : null}"
     >
         <slot name="button-container"
-        @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
         @keydown="${(x, c) => x.keypressHandlerButtonContainer(c.event as KeyboardEvent)}"
+        ${ref("button")}
         >
             <button tabindex="0" part="button" aria-expanded="${x => x.open == true}" aria-haspopup="true">
                 <span part="selected-value">

--- a/components/src/select/select.ts
+++ b/components/src/select/select.ts
@@ -25,6 +25,12 @@ export class Select extends FormAssociated<HTMLInputElement> {
     @observable
     public defaultSlottedNodes: Node[];
 
+    @observable
+    public button: HTMLElement;
+    private buttonChanged(prev: HTMLElement) {
+        this.button.addEventListener("click", this.clickHandler);
+    }
+
     // TODO: This needs to change to support multiple values
     public value: string = "Selected Value"; // Map to proxy element.
     private valueChanged(): void {
@@ -139,7 +145,6 @@ export class Select extends FormAssociated<HTMLInputElement> {
 
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     public clickHandler = (e: MouseEvent): void => {
-        console.log('select click handler');
         if (!this.disabled && !this.readOnly) {
             this.open = !this.open;
 


### PR DESCRIPTION
FAST-Element currently declaratively binds event listeners with the capture option set to true. For this example, the event listener must fire during the bubble phase to work intuitively. This change adjusts the listener to fire during the bubble phase. 