### PR TITLE
Fixing component name matrix regex to correctly group items that end with 'e' or 'er'

### DIFF
--- a/research/src/components/component-name-matrix.js
+++ b/research/src/components/component-name-matrix.js
@@ -11,18 +11,18 @@ const SORT_NEXT = {
   MATCH_COUNT: SORT_OPTIONS.COMPONENT_NAME,
 }
 
-const ComponentNameMatrix = props => {
+const ComponentNameMatrix = (props) => {
   const [sort, setSort] = useState(SORT_OPTIONS.COMPONENT_NAME)
 
-  const getMatchName = name =>
+  const getMatchName = (name) =>
     name
       .replace(/ /gi, '')
       .toLowerCase()
-      .replace(/(\w+)(e|s|es|er|ing)$/, '$1')
+      .replace(/(\w+)(e|er)?(s|ing)$/, '$1')
 
   const matchNameMap = new Map([])
 
-  const matchNames = componentOriginalNames.map(name => {
+  const matchNames = componentOriginalNames.map((name) => {
     const matchName = getMatchName(name)
     matchNameMap.set(name, matchName)
     return matchName
@@ -92,7 +92,7 @@ const ComponentNameMatrix = props => {
           })}
         </div>
 
-        {_.map(sources, source => (
+        {_.map(sources, (source) => (
           <div key={source.name} style={colStyle}>
             <strong style={headerStyle}>
               <a target="_blank" rel="noopener noreferrer" href={source.url}>


### PR DESCRIPTION
Components whose names ended with "e" or "er" where not grouped together with their plural counterpants because of an error in the regex. This PR fixes that issue.

__Before:__

![image](https://user-images.githubusercontent.com/7798177/87737978-2ef1b800-c791-11ea-91db-9972d4746938.png)

![image](https://user-images.githubusercontent.com/7798177/87737987-3618c600-c791-11ea-8951-d7f87e58e1af.png)

__After:__

![image](https://user-images.githubusercontent.com/7798177/87738002-3fa22e00-c791-11ea-97bf-4862956a1cb0.png)

![image](https://user-images.githubusercontent.com/7798177/87738014-46c93c00-c791-11ea-9117-98f3dd8c7c43.png)
