### PR TITLE
fix(image): fix property typo

### DIFF
--- a/research/src/components/image.js
+++ b/research/src/components/image.js
@@ -9,7 +9,7 @@ const Image = ({ src, alt = src, style, ...rest }) => {
   return (
     <img
       alt={alt}
-      srcset={imageData + ' 2x'}
+      srcSet={imageData + ' 2x'}
       style={{
         display: 'inline-block',
         verticalAlign: 'middle',


### PR DESCRIPTION
property `srcset` throws console error since the expected property is `srcSet`

![Screenshot 2020-07-17 at 09 35 01](https://user-images.githubusercontent.com/8545105/87761098-2d67d480-c811-11ea-855f-6417b9b533ed.png)
