### PR TITLE
Create section defining 'light dismiss' behavior of `<select>` listbox part

### DIFF
--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -201,12 +201,17 @@ and is therefore considered to be invalid.
   - Selecting one, or more (if `multiple` is true), options by clicking or hitting the `enter` or `space` key
 
 ### Light dismiss
+
 The listbox part has "light dismiss", behavior, defined as being dismissed (removing
 the `open` state of the `<select>`, in this case) by either of the following things:
+
 - The user presses the escape key.
-- Focus moves outside of the subtree of the listbox (because of either user interaction or script),
-  *except* in the case where focus was switched to the `<body>` element due to a user invoking a
-  non-focusable element inside the subtree of the listbox.
+- A focus change occurs (because of either user interaction or script), where the focus
+  target is outside of the subtree of the listbox. This includes the case where the user
+  invokes a non-focusable element, which causes focus to switch to the `<body>`.
+  - There is one exception to this: if a user invokes a non-focusable element
+    in the subtree of the listbox, focus still moves to the `<body>`, but "light
+    dismiss" does not occur.
 
 ### Keyboard traversal
 

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -195,11 +195,19 @@ and is therefore considered to be invalid.
 - The currently selected `<option>`, or the first if one isn't selected, should be
   visible within the listbox. This may require moving the list to accomodate listbox positioning
   and available space.
-- The user can dismiss the listbox and remove the state of `open` from the `<select>` in any of the
+- The user can dismiss the listbox and remove the state of `open` from the `<select>` in either of the
   following manners:
-  - The user clicks outside of the listbox
-  - Presses the escape key
-  - Selects one, or more (if `multiple` is true), by clicking or hitting `enter` or `space` key
+  - Triggering any of the listbox's <a href="#light-dismiss">light dismiss</a> behaviors
+  - Selecting one, or more (if `multiple` is true), options by clicking or hitting the `enter` or `space` key
+
+### Light dismiss <a class="link" href="#light-dismiss" id="light-dismiss"></a>
+The listbox part has "light dismiss", behavior, defined as being dismissed (removing
+the `open` state of the `<select>`, in this case) by either of the following things:
+- The user presses the escape key.
+- Focus moves outside of the subtree of the element with <a href="#light-dismiss">light dismiss</a>
+  (because of either user interaction or script), *except* in the case where focus was switched to the
+  `<body>` element due to a user invoking a non-focusable element inside the subtree of the element
+  with <a href="#light-dismiss">light dismiss</a>.
 
 ### Keyboard traversal
 

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -200,7 +200,7 @@ and is therefore considered to be invalid.
   - Triggering any of the listbox's <a href="#light-dismiss">light dismiss</a> behaviors
   - Selecting one, or more (if `multiple` is true), options by clicking or hitting the `enter` or `space` key
 
-### Light dismiss <a class="link" href="#light-dismiss" id="light-dismiss"></a>
+### Light dismiss
 The listbox part has "light dismiss", behavior, defined as being dismissed (removing
 the `open` state of the `<select>`, in this case) by either of the following things:
 - The user presses the escape key.

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -204,10 +204,9 @@ and is therefore considered to be invalid.
 The listbox part has "light dismiss", behavior, defined as being dismissed (removing
 the `open` state of the `<select>`, in this case) by either of the following things:
 - The user presses the escape key.
-- Focus moves outside of the subtree of the element with <a href="#light-dismiss">light dismiss</a>
-  (because of either user interaction or script), *except* in the case where focus was switched to the
-  `<body>` element due to a user invoking a non-focusable element inside the subtree of the element
-  with <a href="#light-dismiss">light dismiss</a>.
+- Focus moves outside of the subtree of the listbox (because of either user interaction or script),
+  *except* in the case where focus was switched to the `<body>` element due to a user invoking a
+  non-focusable element inside the subtree of the listbox.
 
 ### Keyboard traversal
 


### PR DESCRIPTION
Create a new section to define "light dismiss" behavior for the `<select>` listbox part, and reference the new section from the Open State Section.

Ideally we would describe this behavior in terms of a `blur` or `focusout` event, but it turns out that both of these are not adequate for the task; see #137.  To achieve this behavior today would require a combination of multiple JS events to prevent the listbox from collapsing when non-focusable content inside the listbox is clicked.  In the future we could consider fleshing out the light dismiss section to clearly specify this combination, or reference a new platform primitive if one is introduced to make this easier.

Closes #137 .