### PR TITLE
Add some missing text in 'part button' table

### DIFF
--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -126,36 +126,36 @@ children:
 
 ### part button
 
-| Event            | Behavior                                     | Impacts                                                                 |
-| ---------------- | -------------------------------------------- | ----------------------------------------------------------------------- |
-| `click`          | Toggles the `open` state of the `<select>`   | [open](#open-state) state                                               |
-| `click`          | Toggles `aria-expanded` attribute            | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
-| `keydown(space)` | Toggles the `open` state on the `<select>`   | [open](#open-state) state                                               |
-| `keydown(space)` | Toggles `aria-expanded`                      | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
-| `keydown(enter)` | Toggles the `open` state on th               | [open](#open-state) state                                               |
-| `keydown(enter)` | Toggles `aria-expanded` on the `button part` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
+| Event            | Behavior                                          | Impacts                                                                 |
+| ---------------- | ------------------------------------------------- | ----------------------------------------------------------------------- |
+| `click`          | Toggles the `open` state of the `<select>`        | [open](#open-state) state                                               |
+| `click`          | Toggles `aria-expanded` attribute of the `button` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
+| `keydown(space)` | Toggles the `open` state of the `<select>`        | [open](#open-state) state                                               |
+| `keydown(space)` | Toggles `aria-expanded` attribute of the `button` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
+| `keydown(enter)` | Toggles the `open` state of the `<select>`        | [open](#open-state) state                                               |
+| `keydown(enter)` | Toggles `aria-expanded` of the `button part`      | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
 
 ### part listbox
 
-| Event               | Behavior                                                                                                                    | Impacts                                                                 |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `keydown(down key)` | Moves focus to the next `<option>` in the listbox                                                                           | focus                                                                   |
-| `keydown(up key)`   | Moves focus to the previous `<option>` in the listbox                                                                       | focus                                                                   |
-| `keydown(enter)`    | Changes the `selected` state of the current `<option>` and updates the `<select>` value property                            | [selected](#selected) prop <br/> [value](#value) prop                   |
-| `keydown(space)`    | Changes the `selected` state of the current `<option>` and updates the `<select>` value property                            | [selected](#selected) prop <br/> [value](#value) prop                   |
-| `keydown(enter)`    | If the `<select>` does **not** have the `multiple` attribute then toggle the state of `open` on the `<select>`              | [open](#open-state) state                                               |
-| `keydown(enter)`    | If the `<select>` does **not** have the `multiple` attribute then toggle the `aria-expanded` attribute on the `button part` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
-| `keydown(space)`    | If the `<select>` does **not** have the `multiple` attribute then toggle the state of `open` on the `<select>`              | [open](#open-state) state                                               |
-| `keydown(space)`    | If the `<select>` does **not** have the `multiple` attribute then toggle the `aria-expanded` attribute on the `button part` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
-| `keydown(escape)`   | Toggles the `open` state of the `<select>`                                                                                  | [open](#open-state) state                                               |
+| Event               | Behavior                                                                                                               | Impacts                                                                 |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `keydown(down key)` | Moves focus to the next `<option>` in the `listbox`                                                                    | focus                                                                   |
+| `keydown(up key)`   | Moves focus to the previous `<option>` in the `listbox`                                                                | focus                                                                   |
+| `keydown(enter)`    | Changes the `selected` state of the current `<option>` and updates the `<select>` value property                       | [selected](#selected) prop <br/> [value](#value) prop                   |
+| `keydown(space)`    | Changes the `selected` state of the current `<option>` and updates the `<select>` value property                       | [selected](#selected) prop <br/> [value](#value) prop                   |
+| `keydown(enter)`    | If the `<select>` does **not** have the `multiple` attribute then toggle the state of `open` of the `<select>`         | [open](#open-state) state                                               |
+| `keydown(enter)`    | If the `<select>` does **not** have the `multiple` attribute then toggle the `aria-expanded` attribute of the `button` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
+| `keydown(space)`    | If the `<select>` does **not** have the `multiple` attribute then toggle the state of `open` of the `<select>`         | [open](#open-state) state                                               |
+| `keydown(space)`    | If the `<select>` does **not** have the `multiple` attribute then toggle the `aria-expanded` attribute of the `button` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
+| `keydown(escape)`   | Toggles the `open` state of the `<select>`                                                                             | [open](#open-state) state                                               |
 
 ### part option
 
-| Event   | Behavior                                                                                                                    | Impacts                                                                 |
-| ------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `click` | Changes the `selected` state of the current `<option>` and updates the `<select>` value property                            | [selected](#selected) prop <br/> [value](#value) prop                   |
-| `click` | If the `<select>` does **not** have the `multiple` attribute then toggle the state of `open` on the `<select>`              | [open](#open-state) state                                               |
-| `click` | If the `<select>` does **not** have the `multiple` attribute then toggle the `aria-expanded` attribute on the `button part` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
+| Event   | Behavior                                                                                                               | Impacts                                                                 |
+| ------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `click` | Changes the `selected` state of the current `<option>` and updates the `<select>` value property                       | [selected](#selected) prop <br/> [value](#value) prop                   |
+| `click` | If the `<select>` does **not** have the `multiple` attribute then toggle the state of `open` of the `<select>`         | [open](#open-state) state                                               |
+| `click` | If the `<select>` does **not** have the `multiple` attribute then toggle the `aria-expanded` attribute of the `button` | [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attr |
 
 ## Behavior
 


### PR DESCRIPTION
Add some text that was missing in a `keydown(space)` row of https://open-ui.org/components/select#part-button.
Also fix some really nitpicky consistency issues I noticed in the tables while there:
- The button part was referenced by `button part`, the listbox part was listbox (without the formatting).  Made these `button`/`listbox`.  Happy to do this a different way if there are other preferences, I just wanted them to be consistent.
- "On the" and "of the" were used arbitrarily to reference states and attributes of/on an element or part.  I chose (arbitrarily) "of the" to switch all these to.  I'm also fine using "on the", or even "on the" for attributes and "of the" for states, I just thing it looks (very slightly) better if there is some consistent scheme.