### PR TITLE
fix(ComponentsMatrix): fix large names display

### DIFF
--- a/research/src/components/component-name-matrix.js
+++ b/research/src/components/component-name-matrix.js
@@ -114,12 +114,22 @@ const ComponentNameMatrix = (props) => {
 
               return foundComponent ? (
                 <a
+                  title={foundComponent.name}
                   target="_blank"
                   rel="noopener noreferrer"
                   href={foundComponent.url}
                   style={style}
                 >
-                  {foundComponent.name}
+                  <span
+                    style={{
+                      maxWidth: '55px',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {foundComponent.name}
+                  </span>
                 </a>
               ) : (
                 <div key={matchName} style={style} />


### PR DESCRIPTION
- fixes: #23 

Handle big names in the components matrix by using ellipsis as overflow and title for hover name:

![Screenshot 2020-08-18 at 11 05 29](https://user-images.githubusercontent.com/8545105/90493765-0c154380-e143-11ea-95cd-f8eccf2b29a6.png)
 