### PR TITLE
+meetings May-Aug

### DIFF
--- a/meetings/telecon/meetings.md
+++ b/meetings/telecon/meetings.md
@@ -6,6 +6,9 @@ meetings, their agenda's and call in information please join the Open UI communi
 -----------
 
 ## 2020
-
+- August 18: CSSWG + Open UI ([Agenda] | [Minutes])
+- July 2: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Jun/0002.html) | [Minutes])
+- June 4: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Jun/0000.html) | [Minutes])
+- May 22: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020May/0001.html) | [Minutes])
 - April 24: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Apr/0005.html) | [Minutes](https://www.w3.org/2020/04/24-openui-minutes.html))
 - April 10: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Apr/0002.html) | [Minutes](https://www.w3.org/2020/04/10-openui-minutes.html))

--- a/meetings/telecon/meetings.md
+++ b/meetings/telecon/meetings.md
@@ -7,8 +7,8 @@ meetings, their agenda's and call in information please join the Open UI communi
 
 ## 2020
 - August 18: CSSWG + Open UI ([Agenda] | [Minutes])
-- July 2: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Jun/0002.html) | [Minutes])
-- June 4: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Jun/0000.html) | [Minutes])
-- May 22: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020May/0001.html) | [Minutes])
+- July 2: ([Agenda](https://github.com/WICG/open-ui/blob/master/meetings/telecon/2020-07-02.md) | [Minutes](https://www.w3.org/2020/07/02-openui-minutes.html))
+- June 4: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Jun/0000.html) | [Minutes](https://www.w3.org/2020/06/04-openui-minutes.html))
+- May 22: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020May/0001.html) | [Minutes](https://www.w3.org/2020/05/22-openui-minutes.html))
 - April 24: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Apr/0005.html) | [Minutes](https://www.w3.org/2020/04/24-openui-minutes.html))
 - April 10: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Apr/0002.html) | [Minutes](https://www.w3.org/2020/04/10-openui-minutes.html))


### PR DESCRIPTION
added dates & links to May-July agendas, couldn't find immediate minutes but at least linking to the planned agendas seems like a good idea. and the CSSWG + Open UI meeting happening today.