### PR TITLE
hotfix(concept): remove unecessary role from button

### DIFF
--- a/research/src/components/concept.js
+++ b/research/src/components/concept.js
@@ -39,7 +39,6 @@ export default function Concept({
             e.preventDefault()
             toggleOpen((isOpen) => !isOpen)
           }}
-          role="button"
         >
           <span
             style={{


### PR DESCRIPTION
Remove redundant role for button to avoid the console throw:

<img width="1167" alt="Screenshot 2020-08-21 at 09 38 28" src="https://user-images.githubusercontent.com/8545105/90865074-2002b480-e392-11ea-95b9-15050dc59be9.png">
