### PR TITLE
Changed the heading of components to proposals to reflect what they are

### DIFF
--- a/research/src/components/navigation.js
+++ b/research/src/components/navigation.js
@@ -27,7 +27,7 @@ const Navigation = ({ style }) => (
       const allFrontmatter = _.map(data.allMdx.edges, 'node.frontmatter')
 
       const frontmatterForNav = allFrontmatter
-        .filter(({ name, pathToProposal }) => !!name && !pathToProposal)
+        .filter(({ name, pathToProposal }) => !!name)
         .filter(({ showInMenu }) => showInMenu !== false)
 
       const [menuNodes, topLevelNodes] = _.partition(frontmatterForNav, 'menu')

--- a/research/src/pages/checkbox.proposal.mdx
+++ b/research/src/pages/checkbox.proposal.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Components
+menu: Proposals
 name: Checkbox (Working Draft)
 path: /components/checkbox
 pathToResearch: /components/checkbox.research

--- a/research/src/pages/checkbox.research.mdx
+++ b/research/src/pages/checkbox.research.mdx
@@ -1,7 +1,8 @@
 ---
-name: Checkbox (Working Draft)
+name: Checkbox
 path: /components/checkbox.research
 pathToProposal: /components/checkbox
+menu: Analysis
 ---
 
 import Anatomy from '../components/anatomy'

--- a/research/src/pages/contribute.mdx
+++ b/research/src/pages/contribute.mdx
@@ -225,7 +225,7 @@ The `pathToResearch` key tells your proposal page where its research page is hos
 
 ```
 ---
-menu: Components
+menu: Proposals
 name: Your Component
 path: /components/your-component
 pathToResearch: /components/your-component.research

--- a/research/src/pages/select/select.proposal.mdx
+++ b/research/src/pages/select/select.proposal.mdx
@@ -1,5 +1,5 @@
 ---
-menu: Components
+menu: Proposals
 name: Select (Editor's Draft)
 path: /components/select
 pathToResearch: /components/select.research
@@ -137,7 +137,7 @@ children:
 
 ### part listbox
 
-|                                 Event                                  |                                                        Behavior                                                        |                                 Impacts                                 |
+| Event                                                                  | Behavior                                                                                                               | Impacts                                                                 |
 | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `keydown(down key)`                                                    | Moves focus to the next `<option>` in the `listbox`                                                                    | focus                                                                   |
 | `keydown(up key)`                                                      | Moves focus to the previous `<option>` in the `listbox`                                                                | focus                                                                   |

--- a/research/src/pages/select/select.research.mdx
+++ b/research/src/pages/select/select.research.mdx
@@ -1,7 +1,8 @@
 ---
-name: Select (Working Draft)
+name: Select
 path: /components/select.research
 pathToProposal: /components/select
+menu: Analysis
 ---
 
 import Concepts from '../../components/concepts'

--- a/research/src/pages/table.proposal.mdx
+++ b/research/src/pages/table.proposal.mdx
@@ -1,8 +1,8 @@
 ---
-menu: Components
 name: Table (Editor's Draft)
 path: /components/table
 pathToResearch: /components/table.research
+showInMenu: false
 ---
 
 import TableAnatomy from '../components/table-anatomy'

--- a/research/src/pages/table.research.mdx
+++ b/research/src/pages/table.research.mdx
@@ -1,7 +1,8 @@
 ---
-name: Table (Working Draft)
+name: Table
 path: /components/table.research
 pathToProposal: /components/table
+menu: Analysis
 ---
 
 import Anatomy from '../components/anatomy'


### PR DESCRIPTION
In this change I am adjusting the nav to allow for hidden proposals and analysis to continue to reside under the category rather than removing it when a path-to-proposal is added. This was highlighted by the PR #183 as I'd like to have the link to the skeleton proposal still work. I like this idea as well as the author may want to get the proposal to a certain place before actually proposing it but this will allow the proposal to be worked on without actually being surfaced before their ready to request an Editor's Draft.