### PR TITLE
Updated checkbox anatomy and parts based on resolution

### DIFF
--- a/research/src/components/checkbox-anatomy.js
+++ b/research/src/components/checkbox-anatomy.js
@@ -4,7 +4,7 @@ import './anatomy.css'
 export default () => {
   return (
     <div className="component-anatomy">
-      <host name="checkbox">
+      <host name="oui-checkbox">
         <part name="label">
           <slot name="label"></slot>
         </part>

--- a/research/src/components/checkbox-anatomy.js
+++ b/research/src/components/checkbox-anatomy.js
@@ -8,13 +8,8 @@ export default () => {
         <part name="label">
           <slot name="label"></slot>
         </part>
-        <part name="checkbox">
-          <part name="checked-indicator">
-            <slot></slot>
-          </part>
-          <part name="indeterminate-indicator">
-            <slot></slot>
-          </part>
+        <part name="indicator">
+          <slot></slot>
         </part>
       </host>
     </div>

--- a/research/src/pages/checkbox.proposal.mdx
+++ b/research/src/pages/checkbox.proposal.mdx
@@ -66,11 +66,10 @@ The `<checkbox>` control is primarily leveraged to indicate a binary state. For 
 
 #### Slots
 
-| Slot Name                 | Description                                                   | Fallback Content                                 |
-| ------------------------- | ------------------------------------------------------------- | ------------------------------------------------ |
-| `label`                   | Add custom markup for the control's label                     | Empty                                            |
-| `checked-indicator`       | Content to indicate the checkbox is in a checked state        | Element with checked and indeterminate indcators |
-| `indeterminate-indicator` | Content to indicate the checkbox is in an indeterminate state | Element with checked and indeterminate indcators |
+| Slot Name   | Description                                                             | Fallback Content                                 |
+| ----------- | ----------------------------------------------------------------------- | ------------------------------------------------ |
+| `label`     | Add custom markup for the control's label                               | Empty                                            |
+| `indicator` | Content to indicate the checkbox is in a checked or indeterminate state | Element with checked and indeterminate indcators |
 
 #### CSS Parts
 

--- a/research/src/pages/checkbox.proposal.mdx
+++ b/research/src/pages/checkbox.proposal.mdx
@@ -9,11 +9,11 @@ import CheckboxAnatomy from '../components/checkbox-anatomy'
 
 ## Overview
 
-The `<checkbox>` element is a control that allows the user to select a binary "checked" state, either checked or unchecked. The `<checkbox>` also supports a second binary "indeterminate" state.
+The `<oui-checkbox>` element is a control that allows the user to select a binary "checked" state, either checked or unchecked. The `<oui-checkbox>` also supports a second binary "indeterminate" state.
 
 ### Use Cases
 
-The `<checkbox>` control is primarily leveraged to indicate a binary state. For example, many forms use a checkbox to indicate that a user has accepted _terms of service_ or to opt in or out of email communcations.
+The `<oui-checkbox>` control is primarily leveraged to indicate a binary state. For example, many forms use a checkbox to indicate that a user has accepted _terms of service_ or to opt in or out of email communcations.
 
 ## Prior Art/Examples
 
@@ -93,11 +93,11 @@ The `<checkbox>` control is primarily leveraged to indicate a binary state. For 
 
 #### Keyboard
 
-Keyboard users can operate the `<checkbox>` as follows:
+Keyboard users can operate the `<oui-checkbox>` as follows:
 
-- `<checkbox>` is eligible for document focus.
-- `<checkbox>` is eligible for `autofocus` when the `autofocus` attribute is present on the host.
-- `<checkbox>` can be the target of `click` events (when not `disabled`) either through mouse click, user tap, or keyboard `space` key press.
+- `<oui-checkbox>` is eligible for document focus.
+- `<oui-checkbox>` is eligible for `autofocus` when the `autofocus` attribute is present on the host.
+- `<oui-checkbox>` can be the target of `click` events (when not `disabled`) either through mouse click, user tap, or keyboard `space` key press.
 
 #### Form input
 

--- a/research/src/pages/checkbox.proposal.mdx
+++ b/research/src/pages/checkbox.proposal.mdx
@@ -54,17 +54,14 @@ The `<checkbox>` control is primarily leveraged to indicate a binary state. For 
 #### DOM Structure
 
 ```html
-<host>
-  <label part="label"><slot name="label"></slot></label>
-  <div part="control">
-    <div part="checked-indicator">
-      <slot name="checked-indicator"></slot>
-    </div>
-    <div part="indeterminate-indicator">
-      <slot name="indeterminate-indicator"></slot>
-    </div>
+<oui-checkbox>
+  <label part="label">
+    <slot name="label"></slot>
+  </label>
+  <div part="indicator">
+    <slot name="indicator"></slot>
   </div>
-</host>
+</oui-checkbox>
 ```
 
 #### Slots
@@ -77,11 +74,10 @@ The `<checkbox>` control is primarily leveraged to indicate a binary state. For 
 
 #### CSS Parts
 
-| Slot Name                 | Description                                         |
-| ------------------------- | --------------------------------------------------- |
-| `label`                   | The control's label                                 |
-| `checked-indicator`       | Indicates the checkbox is in a checked state        |
-| `indeterminate-indicator` | Indicates the checkbox is in an indeterminate state |
+| Slot Name   | Description                                                   |
+| ----------- | ------------------------------------------------------------- |
+| `label`     | The control's label                                           |
+| `indicator` | Indicates the checkbox is in a checked or indeterminate state |
 
 ## Behavior
 


### PR DESCRIPTION
This is an update to the checkbox anatomy based on the resolution of https://github.com/WICG/open-ui/issues/199

Additionally, I am adding in the `oui-` namespace for the host to show it's a custom web component and also removed the `part=control` as I don't think there is a need for it especially since it isn't referenced in the rest of the spec.