### PR TITLE
Improve initial load of FontAwesome icons

### DIFF
--- a/research/gatsby-config.js
+++ b/research/gatsby-config.js
@@ -74,6 +74,8 @@ module.exports = {
       },
     },
 
+    'gatsby-plugin-fontawesome-css',
+
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
     // 'gatsby-plugin-offline',

--- a/research/package.json
+++ b/research/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
+    "serve": "gatsby serve",
     "start": "gatsby develop"
   },
   "husky": {
@@ -74,5 +75,8 @@
     "sharp": "^0.25.2",
     "theme-ui": "^0.3.1",
     "typography": "^0.16.19"
+  },
+  "devDependencies": {
+    "gatsby-plugin-fontawesome-css": "^1.0.0"
   }
 }

--- a/research/package.json
+++ b/research/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
+    "clean": "gatsby clean",
     "serve": "gatsby serve",
     "start": "gatsby develop"
   },

--- a/research/package.json
+++ b/research/package.json
@@ -51,6 +51,7 @@
     "anchor-js": "^4.2.2",
     "gatsby": "^2.20.14",
     "gatsby-plugin-favicon": "^3.1.6",
+    "gatsby-plugin-fontawesome-css": "^1.0.0",
     "gatsby-plugin-mdx": "^1.1.6",
     "gatsby-plugin-offline": "^3.1.2",
     "gatsby-plugin-react-helmet": "^3.2.1",
@@ -76,8 +77,5 @@
     "sharp": "^0.25.2",
     "theme-ui": "^0.3.1",
     "typography": "^0.16.19"
-  },
-  "devDependencies": {
-    "gatsby-plugin-fontawesome-css": "^1.0.0"
   }
 }

--- a/research/src/components/logo.js
+++ b/research/src/components/logo.js
@@ -7,7 +7,7 @@ const Logo = ({ siteTitle }) => (
   <Link to="/" style={{ textDecoration: 'none', color: 'inherit' }}>
     <Image
       src="logo-green.png"
-      style={{ height: '2.75em', marginRight: '0.25rem' }}
+      style={{ height: '2.75em', width: '2.75em', marginRight: '0.25rem' }}
       alt={siteTitle}
     />
     <strong style={{ verticalAlign: 'middle' }}>{siteTitle}</strong>

--- a/research/src/utils/typography.js
+++ b/research/src/utils/typography.js
@@ -22,7 +22,14 @@ const typography = new Typography({
   headerGrayHue: 'warm',
 
   // Body
-  bodyFontFamily: ['Source Sans Pro', 'Georgia', 'serif'],
+  bodyFontFamily: [
+    'Source Sans Pro',
+    'Helvetica Neue',
+    'Segoe UI',
+    'Helvetica',
+    'Arial',
+    'sans-serif',
+  ],
   bodyWeight: 400,
   boldWeight: 700,
   bodyGray: 0.2,

--- a/research/yarn.lock
+++ b/research/yarn.lock
@@ -6809,6 +6809,11 @@ gatsby-plugin-favicon@^3.1.6:
     html-react-parser "^0.6.4"
     lodash "^4.17.11"
 
+gatsby-plugin-fontawesome-css@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-fontawesome-css/-/gatsby-plugin-fontawesome-css-1.0.0.tgz#12b0d9e4eb45f9321556e83accfa93fc6627d608"
+  integrity sha512-jToy7WSlNjCtcFWjS7/W1U8jJggKBv2hZhatYyNXELfxvl3eFvuJGlDYYDDKtMzv57N5hbXwUvJ+iW21+FcDOA==
+
 gatsby-plugin-mdx@^1.1.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.2.6.tgz#f97d2131287ca1272ac8aa4eded81c884ebfb439"


### PR DESCRIPTION
Use a Gatsby plugin to improve the initial load of font awesome icons. This plugin inlines the FontAwesome CSS in the `head` of the HTML pages so that when the SVGs are rendered they are properly styled and sized on initial render.

Before (gif that loops twice then stops):
![openui-icon-loading](https://user-images.githubusercontent.com/459878/100646518-f80ce080-32f2-11eb-80d0-691d536a0abd.gif)

After (gif loops 2x):
![openui-icon-loading-improved](https://user-images.githubusercontent.com/459878/100646932-9436e780-32f3-11eb-9229-9388944b1f87.gif)

Also:
* Specify a width for the OpenUI logo image to avoid the OpenUI text jumping once the logo image loads
* Specify similar fallback typefaces for our body font. "Source Sans Pro" is a sans-serif font while the original fallbacks were serif fonts. I've adjusted the fallbacks to also be sans-serif fonts so the shift in typeface (once Source Sans Pro loads from Google Fonts) is a little less dramatic
* Add yarn scripts for `gatsby clean` and `gatsby serve`. I often use these to test my changes on a production build to ensure the end-user experience is what I expect (since the development environment is very different from what is deployed).