### PR TITLE
Move site nav into a menu on smaller screens

### DIFF
--- a/research/package.json
+++ b/research/package.json
@@ -45,6 +45,7 @@
     "@emotion/core": "^10.0.28",
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-brands-svg-icons": "^5.13.0",
+    "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.9",
     "@mdx-js/mdx": "^1.5.8",
     "@mdx-js/react": "^1.5.8",

--- a/research/src/components/community-links.js
+++ b/research/src/components/community-links.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons'
+
+export default function CommunityLinks({ githubURL, className = '' }) {
+  return (
+    <div className={'community-links ' + className}>
+      <a href={githubURL} target="_blank" rel="noreferrer noopener" style={{ color: 'inherit' }}>
+        <FontAwesomeIcon style={{ marginRight: '0.2em' }} icon={faGithub} /> GitHub
+      </a>
+
+      <a
+        href="https://discord.gg/DEWjhSw"
+        target="_blank"
+        rel="noreferrer noopener"
+        style={{ color: 'inherit' }}
+      >
+        <FontAwesomeIcon style={{ marginRight: '0.2em', marginLeft: '1em' }} icon={faDiscord} />{' '}
+        Discord
+      </a>
+    </div>
+  )
+}

--- a/research/src/components/global.css
+++ b/research/src/components/global.css
@@ -14,10 +14,6 @@
 }
 
 @media (max-width: 640px) {
-  .header-nav {
-    display: none;
-  }
-
   .header-menu-btn[type='button'] {
     display: block;
   }
@@ -35,6 +31,27 @@
 @media (max-width: 640px) {
   .page-wrapper {
     flex-direction: column;
+  }
+}
+
+/*      Community Links    */
+.community-links {
+  display: block;
+}
+
+.community-links.mobile {
+  display: none;
+  justify-content: space-around;
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 640px) {
+  .community-links {
+    display: none;
+  }
+
+  .community-links.mobile {
+    display: flex;
   }
 }
 

--- a/research/src/components/global.css
+++ b/research/src/components/global.css
@@ -1,3 +1,67 @@
+/*       Header     */
+.header-menu-btn[type='button'] {
+  display: none;
+  padding: 0.25em 0.5em;
+  appearance: none;
+  border: 0;
+  background: none;
+  color: white;
+  cursor: pointer;
+}
+
+.header-menu-btn[type='button']:hover {
+  background-color: #666;
+}
+
+@media (max-width: 640px) {
+  .header-nav {
+    display: none;
+  }
+
+  .header-menu-btn[type='button'] {
+    display: block;
+  }
+}
+
+/*    Page Wrapper  */
+
+.page-wrapper {
+  display: flex;
+  padding: 0 1rem;
+  margin: 0 auto;
+  max-width: 1200px;
+}
+
+@media (max-width: 640px) {
+  .page-wrapper {
+    flex-direction: column;
+  }
+}
+
+/*      Site Nav    */
+#site-nav {
+  margin-right: 2em;
+}
+
+#site-nav > ul {
+  position: sticky;
+}
+
+@media (max-width: 640px) {
+  #site-nav {
+    display: none;
+    margin-right: 0;
+  }
+
+  #site-nav > ul {
+    position: static;
+  }
+
+  #site-nav.opened {
+    display: block;
+  }
+}
+
 /*      AnchorJS    */
 .anchorjs-link {
   color: #aaa;
@@ -37,7 +101,8 @@ table.nowrap-first-column td:nth-child(1) {
   white-space: nowrap;
 }
 
-table.research td.center, table.research th.center {
+table.research td.center,
+table.research th.center {
   text-align: center;
 }
 

--- a/research/src/components/header.js
+++ b/research/src/components/header.js
@@ -3,8 +3,9 @@ import React from 'react'
 import Logo from './logo'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons'
+import { faBars } from '@fortawesome/free-solid-svg-icons'
 
-const Header = ({ siteTitle, githubURL }) => (
+const Header = ({ siteTitle, githubURL, menuOpened, onToggleMenu }) => (
   <header
     style={{
       background: '#333',
@@ -27,19 +28,33 @@ const Header = ({ siteTitle, githubURL }) => (
         <Logo siteTitle={siteTitle} />
       </span>
 
-      <a href={githubURL} target="_blank" rel="noreferrer noopener" style={{ color: 'inherit' }}>
-        <FontAwesomeIcon style={{ marginRight: '0.2em' }} icon={faGithub} /> GitHub
-      </a>
+      <div className="header-nav">
+        <a href={githubURL} target="_blank" rel="noreferrer noopener" style={{ color: 'inherit' }}>
+          <FontAwesomeIcon style={{ marginRight: '0.2em' }} icon={faGithub} /> GitHub
+        </a>
 
-      <a
-        href="https://discord.gg/DEWjhSw"
-        target="_blank"
-        rel="noreferrer noopener"
-        style={{ color: 'inherit' }}
+        <a
+          href="https://discord.gg/DEWjhSw"
+          target="_blank"
+          rel="noreferrer noopener"
+          style={{ color: 'inherit' }}
+        >
+          <FontAwesomeIcon style={{ marginRight: '0.2em', marginLeft: '1em' }} icon={faDiscord} />{' '}
+          Discord
+        </a>
+      </div>
+
+      <button
+        type="button"
+        className="header-menu-btn"
+        aria-label="Toggle menu"
+        title="Toggle menu"
+        onClick={onToggleMenu}
+        aria-expanded={menuOpened ? 'true' : 'false'}
+        aria-controls="site-nav"
       >
-        <FontAwesomeIcon style={{ marginRight: '0.2em', marginLeft: '1em' }} icon={faDiscord} />{' '}
-        Discord
-      </a>
+        <FontAwesomeIcon icon={faBars} size="lg" />
+      </button>
     </div>
   </header>
 )

--- a/research/src/components/header.js
+++ b/research/src/components/header.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import Logo from './logo'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons'
 import { faBars } from '@fortawesome/free-solid-svg-icons'
+import Logo from './logo'
+import CommunityLinks from './community-links'
 
 const Header = ({ siteTitle, githubURL, menuOpened, onToggleMenu }) => (
   <header
@@ -28,21 +28,7 @@ const Header = ({ siteTitle, githubURL, menuOpened, onToggleMenu }) => (
         <Logo siteTitle={siteTitle} />
       </span>
 
-      <div className="header-nav">
-        <a href={githubURL} target="_blank" rel="noreferrer noopener" style={{ color: 'inherit' }}>
-          <FontAwesomeIcon style={{ marginRight: '0.2em' }} icon={faGithub} /> GitHub
-        </a>
-
-        <a
-          href="https://discord.gg/DEWjhSw"
-          target="_blank"
-          rel="noreferrer noopener"
-          style={{ color: 'inherit' }}
-        >
-          <FontAwesomeIcon style={{ marginRight: '0.2em', marginLeft: '1em' }} icon={faDiscord} />{' '}
-          Discord
-        </a>
-      </div>
+      <CommunityLinks githubURL={githubURL} />
 
       <button
         type="button"

--- a/research/src/components/layout.js
+++ b/research/src/components/layout.js
@@ -60,11 +60,7 @@ const Layout = ({ children, pageContext }) => {
   const onToggleMenu = React.useCallback(() => setOpen((opened) => !opened), [setOpen])
 
   const { frontmatter } = pageContext || {}
-
-  const ContentWrapper =
-    frontmatter && frontmatter.path && frontmatter.path.startsWith('/components/')
-      ? ComponentLayout
-      : ({ children }) => <>{children}</>
+  const useComponentLayout = frontmatter?.path?.startsWith('/components/') ?? false
 
   return (
     <StaticQuery
@@ -92,7 +88,11 @@ const Layout = ({ children, pageContext }) => {
               <Navigation opened={opened} />
 
               <div style={{ flex: '1 1 auto', minWidth: 0 }}>
-                <ContentWrapper frontmatter={frontmatter}>{children}</ContentWrapper>
+                {useComponentLayout ? (
+                  <ComponentLayout frontmatter={frontmatter}>{children}</ComponentLayout>
+                ) : (
+                  children
+                )}
               </div>
             </div>
           </div>

--- a/research/src/components/layout.js
+++ b/research/src/components/layout.js
@@ -56,6 +56,9 @@ const components = {
 }
 
 const Layout = ({ children, pageContext }) => {
+  const [opened, setOpen] = React.useState(false)
+  const onToggleMenu = React.useCallback(() => setOpen((opened) => !opened), [setOpen])
+
   const { frontmatter } = pageContext || {}
 
   const ContentWrapper =
@@ -82,16 +85,11 @@ const Layout = ({ children, pageContext }) => {
             <Header
               siteTitle={data.site.siteMetadata.title}
               githubURL={data.site.siteMetadata.githubURL}
+              menuOpened={opened}
+              onToggleMenu={onToggleMenu}
             />
-            <div
-              style={{
-                display: 'flex',
-                padding: '0 1rem',
-                margin: '0 auto',
-                maxWidth: '1200px',
-              }}
-            >
-              <Navigation style={{ marginRight: '2em' }} />
+            <div className="page-wrapper">
+              <Navigation opened={opened} />
 
               <div style={{ flex: '1 1 auto', minWidth: 0 }}>
                 <ContentWrapper frontmatter={frontmatter}>{children}</ContentWrapper>

--- a/research/src/components/layout.js
+++ b/research/src/components/layout.js
@@ -85,9 +85,9 @@ const Layout = ({ children, pageContext }) => {
               onToggleMenu={onToggleMenu}
             />
             <div className="page-wrapper">
-              <Navigation opened={opened} />
+              <Navigation opened={opened} githubURL={data.site.siteMetadata.githubURL} />
 
-              <div style={{ flex: '1 1 auto', minWidth: 0 }}>
+              <div className="page-content" style={{ flex: '1 1 auto', minWidth: 0 }}>
                 {useComponentLayout ? (
                   <ComponentLayout frontmatter={frontmatter}>{children}</ComponentLayout>
                 ) : (

--- a/research/src/components/navigation.js
+++ b/research/src/components/navigation.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { StaticQuery, graphql, Link } from 'gatsby'
 
-const Navigation = ({ style }) => (
+const Navigation = ({ opened }) => (
   <StaticQuery
     query={graphql`
       query NavigationQuery {
@@ -65,8 +65,8 @@ const Navigation = ({ style }) => (
       )
 
       return (
-        <nav style={style}>
-          <ul style={{ position: 'sticky', top: '1em', margin: 0 }}>
+        <nav id="site-nav" className={opened ? 'opened' : ''}>
+          <ul style={{ top: '1em', margin: 0 }}>
             <li
               key="Home"
               style={{

--- a/research/src/components/navigation.js
+++ b/research/src/components/navigation.js
@@ -2,8 +2,9 @@ import _ from 'lodash'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { StaticQuery, graphql, Link } from 'gatsby'
+import CommunityLinks from './community-links'
 
-const Navigation = ({ opened }) => (
+const Navigation = ({ opened, githubURL }) => (
   <StaticQuery
     query={graphql`
       query NavigationQuery {
@@ -66,6 +67,8 @@ const Navigation = ({ opened }) => (
 
       return (
         <nav id="site-nav" className={opened ? 'opened' : ''}>
+          <CommunityLinks githubURL={githubURL} className={'mobile'} />
+
           <ul style={{ top: '1em', margin: 0 }}>
             <li
               key="Home"

--- a/research/yarn.lock
+++ b/research/yarn.lock
@@ -1132,6 +1132,11 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.28.tgz#1091bdfe63b3f139441e9cba27aa022bff97d8b2"
   integrity sha512-gtis2/5yLdfI6n0ia0jH7NJs5i/Z/8M/ZbQL6jXQhCthEOe5Cr5NcQPhgTvFxNOtURE03/ZqUcEskdn2M+QaBg==
 
+"@fortawesome/fontawesome-common-types@^0.2.32":
+  version "0.2.32"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz#3436795d5684f22742989bfa08f46f50f516f259"
+  integrity sha512-ux2EDjKMpcdHBVLi/eWZynnPxs0BtFVXJkgHIxXRl+9ZFaHPvYamAfCzeeQFqHRjuJtX90wVnMRaMQAAlctz3w==
+
 "@fortawesome/fontawesome-svg-core@^1.2.28":
   version "1.2.28"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.28.tgz#e5b8c8814ef375f01f5d7c132d3c3a2f83a3abf9"
@@ -1145,6 +1150,13 @@
   integrity sha512-/6xXiJFCMEQxqxXbL0FPJpwq5Cv6MRrjsbJEmH/t5vOvB4dILDpnY0f7zZSlA8+TG7jwlt12miF/yZpZkykucA==
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.28"
+
+"@fortawesome/free-solid-svg-icons@^5.15.1":
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.1.tgz#e1432676ddd43108b41197fee9f86d910ad458ef"
+  integrity sha512-EFMuKtzRMNbvjab/SvJBaOOpaqJfdSap/Nl6hst7CgrJxwfORR1drdTV6q1Ib/JVzq4xObdTDcT6sqTaXMqfdg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.32"
 
 "@fortawesome/react-fontawesome@^0.1.9":
   version "0.1.9"


### PR DESCRIPTION
On screens up to 640px wide, the site navigation is moved into a menu that is toggled on click. For this PR, I wanted to keep it very simple to serve as a stop-gap (as suggested in #170) until the proposed re-design in #29 happens.

![openui-mobile-menu](https://user-images.githubusercontent.com/459878/101088238-352dd880-3568-11eb-82ab-c69eafac9af9.gif)

Some current limitations I'll tackle in future PRs
* The select & checkbox proposal pages as well as the component name matrix page have tables that overflow the page on small screens. I'll investigate making this mobile friendly later.
* The mobile menu isn't interactive until our JS loads which is currently a 1.2 MB (😱) minified gzipped file. I imagine on a phone with a spotty connection it may take some time to load. In another PR I'll investigate reducing this bundle size so the mobile menu can become interactive faster.

I'll add some additional context to specific changes in the comments below.

Related: #170 