### PR TITLE
Remove meeting list, add info on how to join and how to participate

### DIFF
--- a/meetings/telecon/chair-meeting.md
+++ b/meetings/telecon/chair-meeting.md
@@ -1,8 +1,8 @@
 # How to setup a meeting
 
 1. Create a new MD file in the telecon [folder](https://github.com/WICG/open-ui/tree/master/meetings/telecon)
-2. Go to Issues and search for the `Agenda+` label. If there are any take the oldest ones and add them to the 
-list of the agenda. If you think the agenda is a little light review the issues and PRs to see if there are 
+2. Go to Issues and search for the `Agenda+` label. If there are any take the oldest ones and add them to the
+list of the agenda. If you think the agenda is a little light review the issues and PRs to see if there are
 any that seem ready for review and add them. Place these into the file you created.
 3. In the Open UI calendar invite the Google Meet URL is there, place that into the telecon below the agenda
 4. Copy the Github URL to the markdown file you created and paste this into the `#telecon-agenda` channel of Discord
@@ -19,18 +19,22 @@ any that seem ready for review and add them. Place these into the file you creat
 
 # Make progress on issues
 
-1. The goal of the meeting is to get to a resolution. So allow the person that owns the issue/PR to go over the item, but 
-if there isn't a clear concise request for feedback help request that. It's easy to generally discuss things for 30 minutes which 
-isn't inherently bad but the goal of the telecons is to drive consense. If it seems you can't achieve that then recommend taking 
+1. The goal of the meeting is to get to a resolution. So allow the person that owns the issue/PR to go over the item, but
+if there isn't a clear concise request for feedback help request that. It's easy to generally discuss things for 30 minutes which
+isn't inherently bad but the goal of the telecons is to drive consense. If it seems you can't achieve that then recommend taking
 it back to the Github issue and for people to weigh in there and we'll resolve at the next meeting
-2. If there is a resolution make sure to initially get the `Proposed Resolution: <Resolution>` out and to gain consensus. If there are no objections 
+2. If there is a resolution make sure to initially get the `Proposed Resolution: <Resolution>` out and to gain consensus. If there are no objections
 then retype it but prepended with `Resolved: <Resolution>`. This will make it highlighted in the minutes.
 3. If there isn't a resolution but a specific action (eg: do research on xyz) denote it with `ACTION: <Their IRC name> <Action>`
 
 # Ending the meeting
 
-1. Just like starting the meeting, end the meeting by `Zakim, end meeting`. Zakim will tell the RRSAgent to generate minutes and 
+1. Just like starting the meeting, end the meeting by `Zakim, end meeting`. Zakim will tell the RRSAgent to generate minutes and
 the RRSAgent will provide the URL where the generated minutes will end up (it depends on the queue but normally is done in a few minutes)
 2. Take the URL and place that below your agenda with the heading of Minutes
 3. Place in resolutions (copy the text verbatim) and put them in under a heading of Resolutions & Actions. Do the same with Actions.
 4. Paste the link to the telecon file in Github into the `#general` Discord channel (eg: Here are the minutes from today's telecon, thanks for joining: <URL>)
+
+# Participating in a meeting
+
+Please see [`meetings.md`](https://github.com/WICG/open-ui/blob/master/meetings/telecon/meetings.md) for more information.

--- a/meetings/telecon/meetings.md
+++ b/meetings/telecon/meetings.md
@@ -1,16 +1,54 @@
-# Minutes
+# Meetings
 
-Below is a list to our meeting minutes. If you'd like to stay up to date on upcoming
+We meet weekly to discuss progress on Open UI initiatives. Topics of
+conversation are determined beforehand, and listed in
+[telecon agenda documents](https://github.com/WICG/open-ui/tree/master/meetings/telecon).
+
+Meetings are held on Thursdays from [19:00 PM UTC to 19:45 PM UTC](https://www.worldtimebuddy.com/).
+
+## Minutes
+
+The [`telecon/` directory](https://github.com/WICG/open-ui/tree/master/meetings/telecon) contains meeting minutes. If you'd like to stay up to date on upcoming
 meetings, their agenda's and call in information please join the Open UI community group [here](https://www.w3.org/community/open-ui/).
 
------------
+## Discord
 
-## 2020
-- September 10: [Agenda & Minutes](https://github.com/WICG/open-ui/blob/master/meetings/telecon/2020-09-10.md)
-- August 27: [Agenda](https://github.com/WICG/open-ui/blob/master/meetings/telecon/2020-08-27.md) | [Minutes](https://www.w3.org/2020/08/27-openui-minutes.html)
-- August 18: CSSWG + Open UI ([Agenda](https://lists.w3.org/Archives/Public/www-style/2020Aug/0016.html) | [Minutes](https://www.w3.org/2020/08/18-css-minutes.html#t01))
-- July 2: ([Agenda](https://github.com/WICG/open-ui/blob/master/meetings/telecon/2020-07-02.md) | [Minutes](https://www.w3.org/2020/07/02-openui-minutes.html))
-- June 4: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Jun/0000.html) | [Minutes](https://www.w3.org/2020/06/04-openui-minutes.html))
-- May 22: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020May/0001.html) | [Minutes](https://www.w3.org/2020/05/22-openui-minutes.html))
-- April 24: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Apr/0005.html) | [Minutes](https://www.w3.org/2020/04/24-openui-minutes.html))
-- April 10: ([Agenda](https://lists.w3.org/Archives/Public/public-open-ui/2020Apr/0002.html) | [Minutes](https://www.w3.org/2020/04/10-openui-minutes.html))
+Telecon agendas are announced in the #telecon-agendas channel in [our Discord
+server](https://discord.gg/W5QNec). If you join Discord, be sure to introduce
+yourself in the #introductions channel.
+
+## IRC
+
+We use IRC during the weekly telecon meetings. To join, #openui on
+[irc.w3.org](http://irc.w3.org/). If you are unfamiliar with IRC, here is a
+[quickstart guide](https://opensource.com/article/16/6/irc-quickstart-guide).
+
+### Commands
+
+We use the following commands to help run our meetings:
+
+- `q+`/`q-`: Add or remove a question from the queue. This helps the person
+running the meeting ensure nobody is overlooked who has a question.
+- `present+`/`present-`: Add or remove yourself from the presentation queue.
+- This signals to the person running the meeting that you have a presentation
+    you would like to give, as well as marking it completed or no longer
+    necessary.
+
+### Note-taking
+
+We have someone volunteer to take meeting notes every meeting. Notes help us
+keep a record of what was discussed. To take notes, post in #openui using the following format:
+
+```
+who: said what
+```
+
+An example of this is:
+
+```
+ gregwhitworth: I would not want to put that on authors to have every primitive, mix and match etc.
+```
+
+### Setting up and running a meeting
+
+Please refer to [`chair-meeting.md`](https://github.com/WICG/open-ui/blob/master/meetings/telecon/chair-meeting.md).


### PR DESCRIPTION
This PR makes some slight tweaks to `meetings.md`. It:

- Communicates the cadence, day, and time of meetings.
- Links to the Discord server and explains relevant channels and onboarding etiquette.
- Describes how to join IRC and links to help for those who may be less familiar with the service.
- Lists commonly-used IRC commands and why they're used.
- Outlines the expected format for note-taking.

For ease of future maintenance I have also removed the list of meeting notes and linked to `telecon/` instead.