### PR TITLE
Tweak heading hierarchy for ”Design Systems Analysis” page

### DIFF
--- a/research/src/pages/documentation/design-system-analysis-guide.mdx
+++ b/research/src/pages/documentation/design-system-analysis-guide.mdx
@@ -12,7 +12,7 @@ Open UI uses design systems as one of its forms of evidence for cataloging emerg
 Design systems are documented in JSON5 format according a JSON schema.
 This provides us with a consistent and machine readable way of documenting the design system.
 
-**What's a Design System?**
+## What's a Design System?
 
 A design system is a collection of assets and components used to create and maintain UIs on multiple platforms. Examples:
 
@@ -20,7 +20,7 @@ A design system is a collection of assets and components used to create and main
 - [IBM's Carbon Design](https://www.carbondesignsystem.com)
 - Read more [here](https://www.invisionapp.com/inside-design/guide-to-design-systems/)
 
-**Design System Criteria**
+### Design System Criteria
 
 In order to succeed as an open standard, Open UI must collect the most useful ideas and patterns that exist.
 Because of this, not all design systems are suitable to use as Open UI sources.
@@ -39,7 +39,7 @@ A design system does not need to meet all of these criteria but it should meet m
 The design systems we've launched with we believe are representative of these criteria.
 We may not accept PRs contributing design systems that are lacking by these criteria.
 
-### Adding a design system <a href="#add-a-design-system" id="add-a-design-system"></a>
+## Adding a design system <a href="#add-a-design-system" id="add-a-design-system"></a>
 
 Create a JSON5 file in `/sources` for the design system, like `/antd.json5`.
 Add the `$schema` key pointing to our `design-system.schema.json5` schema and complete the required fields.
@@ -128,7 +128,7 @@ You should also have a toggle on the component page to switch between the propos
 
 :smile: You're all set! We're looking forward to your contribution to Open UI!
 
-# Creating a component spec <a href="#document-component" id="document-component"></a>
+## Creating a component spec <a href="#document-component" id="document-component"></a>
 
 Adding a component to Open UI is a research process.
 Because of this, two pages are created for each component; a research page and a proposal page.


### PR DESCRIPTION
Two updates: 

* two headings were marked up with `<p>` and `<strong>`, replaced those by `hx` elements
* tweaked hierarchy so that there's only one `h1`, and “Adding a design system” and “Creating a component spec” are on the same level